### PR TITLE
README.md - URL fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ pyopenmensa
 Python wrapper for the OpenMensa v2 API and python helper for 
 OpenMensa v2 feeds
 
-More information: http://openmensa.org/static/developer
+More information: http://doc.openmensa.org/


### PR DESCRIPTION
Before this fix, the link pointed to the old OpenMensa developer page at http://www.openmensa.org/static/developer/. Now it points to the right location at http://doc.openmensa.org/.
