### PR TITLE
feed: make price typecheck less strict

### DIFF
--- a/feed.py
+++ b/feed.py
@@ -138,10 +138,10 @@ def buildPrices(data, roles=None, regex=default_price_regex,
 
         :rtype: :obj:`dict`: keys are role as str, values are the prices as
              cent count'''
-    if type(data) is dict:
+    if isinstance(data, dict):
         return dict(map(lambda item: (item[0], convertPrice(item[1])),
                         data.items()))
-    elif type(data) in [str, float, int]:
+    elif isinstance(data, (str, float, int)) and not isinstance(data, bool):
         if default is None:
             raise ValueError('You have to call setAdditionalCharges '
                              'before it is possible to pass a string as price')

--- a/tests/feed/test_prices.py
+++ b/tests/feed/test_prices.py
@@ -83,11 +83,24 @@ class TestPriceDictBuilding():
         'others': 414
     }
 
+    single_price_example = {
+        'student': 364
+    }
+
     def test_dict_passthrought(self):
         d = {
             'student': 354,
             'other': 375
         }
+        assert buildPrices(d) == d
+
+    def test_custom_dict_passthrough(self):
+        class CustomDict(dict): pass
+
+        d = CustomDict()
+        d['student'] = 354
+        d['other'] = 375
+
         assert buildPrices(d) == d
 
     def test_dict_type_converting(self):
@@ -100,12 +113,46 @@ class TestPriceDictBuilding():
             ('student', 'employee', 'others')
         ) == self.price_example
 
+    def test_build_from_prices_and_roles_with_custom_types(self):
+        class CustomStr(str): pass
+        class CustomFloat(float): pass
+        class CustomInt(int): pass
+
+        assert buildPrices(
+            [CustomStr('3.64€'), CustomFloat(3.84), CustomInt(414)],
+            ('student', 'employee', 'others')
+        ) == self.price_example
+
     def test_addtional_charges(self):
         assert buildPrices(
             3.64,
             default='student',
             additional={'employee': '0.20€', 'others': 50}
         ) == self.price_example
+
+    def test_build_from_custom_str_subtype(self):
+        class CustomStr(str): pass
+
+        assert buildPrices(
+            CustomStr('3.64€'),
+            default='student',
+        ) == self.single_price_example
+
+    def test_build_from_custom_int_subtype(self):
+        class CustomInt(int): pass
+
+        assert buildPrices(
+            CustomInt(364),
+            default='student',
+        ) == self.single_price_example
+
+    def test_build_from_custom_float_subtype(self):
+        class CustomFloat(float): pass
+
+        assert buildPrices(
+            CustomFloat(3.64),
+            default='student',
+        ) == self.single_price_example
 
     def test_wrong_price_types(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
The price conversion is now able to deal with subclasses of int, float,
str and not only the exact types.

This gives greater flexibility when working with subclasses, as you do not have to explicitly convert to the corresponding supertype.
