### PR TITLE
fixed example to match allowed_price_roles

### DIFF
--- a/doc/feed/parse_helpers.rst
+++ b/doc/feed/parse_helpers.rst
@@ -41,7 +41,7 @@ Also these ways:
 
 - a dictionary with a role to prices mapping::
 
-    buildPrices({'student': '3.64 €', 'employee': 3.84, 'others': 414})
+    buildPrices({'student': '3.64 €', 'employee': 3.84, 'other': 414})
 
 - a iterator about prices and a iterator about roles::
 
@@ -49,12 +49,12 @@ Also these ways:
 
 - base prices and additional costs for other roles::
 
-    buildPrices(3.64, default='student', addtional={'employee': '0.20€', 'others': 50})
+    buildPrices(3.64, default='student', addtional={'employee': '0.20€', 'other': 50})
 
 
 will create::
 
-    {'student': 364, 'employee': 384, 'others': 414}
+    {'student': 364, 'employee': 384, 'other': 414}
 
 The fifth and sixth parameter of :meth:`.LazyBuilder.addMeal` are passed to :func:`.buildPrices` - so there is normally no need to call it directly.
 


### PR DESCRIPTION
`other` has to be in the singular form to match the `allowed_price_roles`: https://github.com/mswart/pyopenmensa/blob/c651da6ace33e2278349636daaa709d043dee6ff/feed.py#L294